### PR TITLE
feat: Add dark and red themes and disable controls when device is not connected

### DIFF
--- a/AscomAlpacaProxy/frontend-vue/.vite/deps/_metadata.json
+++ b/AscomAlpacaProxy/frontend-vue/.vite/deps/_metadata.json
@@ -1,8 +1,0 @@
-{
-  "hash": "e653aa43",
-  "configHash": "cafcefbe",
-  "lockfileHash": "ce6e373b",
-  "browserHash": "4e94027e",
-  "optimized": {},
-  "chunks": {}
-}

--- a/AscomAlpacaProxy/frontend-vue/.vite/deps/package.json
+++ b/AscomAlpacaProxy/frontend-vue/.vite/deps/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/AscomAlpacaProxy/frontend-vue/src/App.vue
+++ b/AscomAlpacaProxy/frontend-vue/src/App.vue
@@ -10,12 +10,15 @@ import Configuration from './components/Configuration.vue'
 import LiveLog from './components/LiveLog.vue'
 import AppModal from './components/AppModal.vue'
 import { useDeviceStore } from './stores/device'
+import { useThemeStore } from './stores/theme'
 
 const store = useDeviceStore()
+const themeStore = useThemeStore()
 const showExplorer = ref(false)
 
 onMounted(() => {
     store.startPolling()
+    // Theme is automatically applied via the theme store initialization
 })
 </script>
 

--- a/AscomAlpacaProxy/frontend-vue/src/assets/css/style.css
+++ b/AscomAlpacaProxy/frontend-vue/src/assets/css/style.css
@@ -2,7 +2,7 @@
     color-scheme: dark;
     /* Forces native controls (scrollbars, selects) to dark mode */
 
-    /* Color Palette - Deep Space Dark */
+    /* Color Palette - Deep Space Dark (Default Theme) */
     --bg-color-start: #0f0c29;
     --bg-color-mid: #302b63;
     --bg-color-end: #24243e;
@@ -30,6 +30,68 @@
     --shadow-soft: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
 }
 
+/* Default Theme (Explicit) - Uses root variables */
+[data-theme="default"] {
+    /* Inherits all root variables */
+    color-scheme: dark;
+}
+
+/* Red Theme - Night Vision Friendly */
+[data-theme="red"] {
+    color-scheme: dark;
+
+    /* Color Palette - Red Theme */
+    /* Pure black with subtle red tints for night vision preservation */
+    --bg-color-start: #000000;
+    --bg-color-mid: #0a0000;
+    --bg-color-end: #000000;
+
+    --surface-color: rgba(139, 0, 0, 0.08);
+    --surface-border: rgba(139, 0, 0, 0.2);
+    --surface-hover: rgba(139, 0, 0, 0.15);
+
+    /* Subdued red tones for buttons */
+    --primary-color: #a62828;
+    --primary-glow: rgba(166, 40, 40, 0.3);
+
+    --accent-color: #8b4545;
+    --text-primary: #dd9999;
+    --text-secondary: #bb6666;
+
+    /* Adjusted status colors for red theme */
+    --success-color: #cc5555;
+    --warning-color: #d47744;
+    --danger-color: #991010;
+}
+
+/* Material Dark Theme */
+[data-theme="dark"] {
+    color-scheme: dark;
+
+    /* Color Palette - Material Design Dark Theme */
+    /* Based on Material Design 3 dark color scheme - Extra Dark */
+    --bg-color-start: #0a0a0a;
+    --bg-color-mid: #0f0f0f;
+    --bg-color-end: #0a0a0a;
+
+    --surface-color: rgba(255, 255, 255, 0.03);
+    --surface-border: rgba(255, 255, 255, 0.08);
+    --surface-hover: rgba(255, 255, 255, 0.05);
+
+    /* Subdued colors for dark mode */
+    --primary-color: #3d7ab8;
+    --primary-glow: rgba(61, 122, 184, 0.25);
+
+    --accent-color: #3d8a7a;
+    --text-primary: #e1e1e1;
+    --text-secondary: #a0a0a0;
+
+    /* Material Design status colors */
+    --success-color: #3d8a7a;
+    --warning-color: #ffb74d;
+    --danger-color: #cf6679;
+}
+
 body {
     font-family: var(--font-main);
     background: linear-gradient(135deg, var(--bg-color-start), var(--bg-color-mid), var(--bg-color-end));
@@ -39,6 +101,17 @@ body {
     margin: 0;
     min-height: 100vh;
     overflow-x: hidden;
+    transition: background 0.5s ease, color 0.3s ease;
+}
+
+/* Smooth theme transitions for all themed elements */
+* {
+    transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+/* Prevent transition on page load */
+.no-transition * {
+    transition: none !important;
 }
 
 /* --- Layout Containers --- */
@@ -195,6 +268,31 @@ body {
         opacity: 1;
         box-shadow: 0 0 15px var(--warning-color);
     }
+}
+
+/* --- Status Badges --- */
+.status-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(0, 0, 0, 0.3);
+    padding: 0.5rem 0.75rem;
+    border-radius: 50px;
+    border: 1px solid var(--surface-border);
+}
+
+.status-badge .label {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+}
+
+.status-badge .value {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-primary);
 }
 
 /* --- Cards & Content --- */
@@ -486,6 +584,43 @@ select option {
     color: #fff;
 }
 
+/* Material Dark Theme Input Styles */
+[data-theme="dark"] input[type="text"],
+[data-theme="dark"] input[type="number"],
+[data-theme="dark"] select {
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] select option {
+    background-color: #0d0d0d;
+    color: #e1e1e1;
+}
+
+[data-theme="dark"] select option:disabled {
+    color: #666;
+    background-color: #0a0a0a;
+    font-style: italic;
+}
+
+/* Red Theme Input Styles */
+[data-theme="red"] input[type="text"],
+[data-theme="red"] input[type="number"],
+[data-theme="red"] select {
+    background: rgba(139, 0, 0, 0.1);
+    color: var(--text-primary);
+}
+
+[data-theme="red"] select option {
+    background-color: #000000;
+    color: #ffcccc;
+}
+
+[data-theme="red"] select option:disabled {
+    color: #8b4545;
+    background-color: #000000;
+}
+
 select option:disabled {
     color: #666;
     background-color: #0f0c29;
@@ -649,6 +784,42 @@ button {
 
 ::-webkit-scrollbar-thumb:hover {
     background: rgba(255, 255, 255, 0.2);
+}
+
+/* Red Theme Scrollbar */
+[data-theme="red"] ::-webkit-scrollbar-track {
+    background: rgba(139, 0, 0, 0.1);
+}
+
+[data-theme="red"] ::-webkit-scrollbar-thumb {
+    background: rgba(204, 51, 51, 0.2);
+}
+
+[data-theme="red"] ::-webkit-scrollbar-thumb:hover {
+    background: rgba(204, 51, 51, 0.3);
+}
+
+/* Red Theme Log Colors */
+[data-theme="red"] .log-line-error {
+    color: #ff4444;
+}
+
+[data-theme="red"] .log-line-warn {
+    color: #ff9966;
+}
+
+[data-theme="red"] .log-line-debug {
+    color: #cc6666;
+}
+
+/* Red Theme Toggle Switches */
+[data-theme="red"] .slider:before {
+    background-color: #8b4545;
+}
+
+[data-theme="red"] input:checked+.slider:before {
+    background-color: #dd9999;
+    box-shadow: 0 0 10px rgba(221, 153, 153, 0.5);
 }
 
 /* --- Collapsible Sections --- */

--- a/AscomAlpacaProxy/frontend-vue/src/components/Header.vue
+++ b/AscomAlpacaProxy/frontend-vue/src/components/Header.vue
@@ -1,9 +1,17 @@
 <script setup>
 import { useDeviceStore } from '../stores/device'
+import { useThemeStore } from '../stores/theme'
 import { storeToRefs } from 'pinia'
 
 const store = useDeviceStore()
+const themeStore = useThemeStore()
 const { firmwareVersion, comPort, connectionStatus, isConnected, proxyVersion } = storeToRefs(store)
+const { currentTheme } = storeToRefs(themeStore)
+const { THEMES } = themeStore
+
+const handleThemeChange = (event) => {
+    themeStore.setTheme(event.target.value)
+}
 </script>
 
 <template>
@@ -13,6 +21,18 @@ const { firmwareVersion, comPort, connectionStatus, isConnected, proxyVersion } 
           <span class="subtitle">Alpaca Driver & Controller <span id="proxy-version-display">{{ proxyVersion }}</span></span>
       </div>
       <div class="header-badges">
+          <div class="theme-selector">
+              <label for="theme-select" class="theme-label">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                  </svg>
+              </label>
+              <select id="theme-select" v-model="currentTheme" @change="handleThemeChange" class="theme-select">
+                  <option :value="THEMES.DEFAULT">Default</option>
+                  <option :value="THEMES.DARK">Dark</option>
+                  <option :value="THEMES.RED">Red</option>
+              </select>
+          </div>
           <div class="status-badge" id="com-port-badge">
               <span class="value">{{ comPort }}</span>
           </div>
@@ -29,5 +49,56 @@ const { firmwareVersion, comPort, connectionStatus, isConnected, proxyVersion } 
 </template>
 
 <style scoped>
-/* Scoped styles can be added here if needed, but we rely on global style.css for now */
+.theme-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(0, 0, 0, 0.3);
+    padding: 0.5rem 0.75rem;
+    border-radius: 50px;
+    border: 1px solid var(--surface-border);
+}
+
+.theme-label {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.theme-label svg {
+    transition: transform 0.3s ease;
+}
+
+.theme-selector:hover .theme-label svg {
+    transform: rotate(20deg);
+}
+
+.theme-select {
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    cursor: pointer;
+    outline: none;
+    padding: 0;
+    font-family: inherit;
+    font-weight: 500;
+}
+
+.theme-select option {
+    background-color: #1a1a2e;
+    color: #fff;
+}
+
+[data-theme="dark"] .theme-select option {
+    background-color: #0d0d0d;
+    color: #e1e1e1;
+}
+
+[data-theme="red"] .theme-select option {
+    background-color: #1a0505;
+    color: #ffcccc;
+}
 </style>

--- a/AscomAlpacaProxy/frontend-vue/src/components/LiveTelemetry.vue
+++ b/AscomAlpacaProxy/frontend-vue/src/components/LiveTelemetry.vue
@@ -3,7 +3,7 @@ import { useDeviceStore } from '../stores/device'
 import { storeToRefs } from 'pinia'
 
 const store = useDeviceStore()
-const { liveStatus, proxyConfig } = storeToRefs(store)
+const { liveStatus, proxyConfig, isConnected } = storeToRefs(store)
 
 const emit = defineEmits(['open-explorer'])
 </script>
@@ -27,7 +27,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">Voltage</span>
         <span class="value" id="status-v">
-            {{ (liveStatus.v || 0).toFixed(2) }} <small>V</small>
+            {{ isConnected ? (liveStatus.v || 0).toFixed(2) : '--' }} <small>V</small>
         </span>
         </div>
 
@@ -35,7 +35,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">Current</span>
         <span class="value" id="status-i">
-            {{ (liveStatus.i && liveStatus.i !== 0 ? liveStatus.i / 1000 : 0).toFixed(2) }} <small>A</small>
+            {{ isConnected ? (liveStatus.i && liveStatus.i !== 0 ? liveStatus.i / 1000 : 0).toFixed(2) : '--' }} <small>A</small>
         </span>
         </div>
 
@@ -43,7 +43,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">Power</span>
         <span class="value" id="status-p">
-            {{ (liveStatus.p || 0).toFixed(2) }} <small>W</small>
+            {{ isConnected ? (liveStatus.p || 0).toFixed(2) : '--' }} <small>W</small>
         </span>
         </div>
 
@@ -51,7 +51,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">Amb Temp</span>
         <span class="value" id="status-t_amb">
-            {{ (liveStatus.t_amb || 0).toFixed(1) }} <small>°C</small>
+            {{ isConnected ? (liveStatus.t_amb || 0).toFixed(1) : '--' }} <small>°C</small>
         </span>
         </div>
 
@@ -59,7 +59,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">Humidity</span>
         <span class="value" id="status-h_amb">
-            {{ (liveStatus.h_amb || 0).toFixed(1) }} <small>%</small>
+            {{ isConnected ? (liveStatus.h_amb || 0).toFixed(1) : '--' }} <small>%</small>
         </span>
         </div>
 
@@ -67,7 +67,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">Dew Point</span>
         <span class="value" id="status-d">
-            {{ (liveStatus.d || 0).toFixed(1) }} <small>°C</small>
+            {{ isConnected ? (liveStatus.d || 0).toFixed(1) : '--' }} <small>°C</small>
         </span>
         </div>
 
@@ -75,7 +75,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">Lens Temp</span>
         <span class="value" id="status-t_lens">
-            {{ (liveStatus.t_lens || 0).toFixed(1) }} <small>°C</small>
+            {{ isConnected ? (liveStatus.t_lens || 0).toFixed(1) : '--' }} <small>°C</small>
         </span>
         </div>
 
@@ -83,7 +83,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">PWM 1</span>
         <span class="value" id="status-pwm1">
-            {{ Math.round(liveStatus.pwm1 || 0) }} <small>%</small>
+            {{ isConnected ? Math.round(liveStatus.pwm1 || 0) : '--' }} <small>%</small>
         </span>
         </div>
 
@@ -91,7 +91,7 @@ const emit = defineEmits(['open-explorer'])
         <div class="telemetry-item">
         <span class="label">PWM 2</span>
         <span class="value" id="status-pwm2">
-            {{ Math.round(liveStatus.pwm2 || 0) }} <small>%</small>
+            {{ isConnected ? Math.round(liveStatus.pwm2 || 0) : '--' }} <small>%</small>
         </span>
         </div>
     </div>

--- a/AscomAlpacaProxy/frontend-vue/src/components/TelemetryCharts.vue
+++ b/AscomAlpacaProxy/frontend-vue/src/components/TelemetryCharts.vue
@@ -105,7 +105,7 @@ const chartOptions = {
     },
     plugins: {
         legend: {
-            labels: { color: '#ccc' }
+            labels: { color: getComputedStyle(document.documentElement).getPropertyValue('--text-secondary') || '#ccc' }
         }
     }
 }

--- a/AscomAlpacaProxy/frontend-vue/src/components/TelemetryExplorer.vue
+++ b/AscomAlpacaProxy/frontend-vue/src/components/TelemetryExplorer.vue
@@ -290,16 +290,16 @@ const chartOptions = {
             type: 'linear',
             position: 'left',
             beginAtZero: false,
-            grid: { color: 'rgba(255,255,255,0.1)' },
-            ticks: { color: '#00ced1' }, // Cyan for environmental data
+            grid: { color: getComputedStyle(document.documentElement).getPropertyValue('--surface-border') || 'rgba(255,255,255,0.1)' },
+            ticks: { color: getComputedStyle(document.documentElement).getPropertyValue('--primary-color') || '#00ced1' },
             title: { display: false }
         },
         y_right: {
             type: 'linear',
             position: 'right',
             beginAtZero: false,
-            grid: { drawOnChartArea: false }, // Don't draw grid lines for right axis
-            ticks: { color: '#ffd700' }, // Gold for electrical data
+            grid: { drawOnChartArea: false },
+            ticks: { color: getComputedStyle(document.documentElement).getPropertyValue('--accent-color') || '#ffd700' },
             title: { display: false }
         },
         y_bool: {
@@ -307,15 +307,15 @@ const chartOptions = {
             display: false,
             position: 'right',
             min: 0,
-            max: 1 // 1 is 100% height
+            max: 1
         },
         x: {
-            grid: { color: 'rgba(255,255,255,0.1)' },
-            ticks: { maxTicksLimit: 20 }
+            grid: { color: getComputedStyle(document.documentElement).getPropertyValue('--surface-border') || 'rgba(255,255,255,0.1)' },
+            ticks: { maxTicksLimit: 20, color: getComputedStyle(document.documentElement).getPropertyValue('--text-secondary') || '#b0b0b0' }
         }
     },
     plugins: {
-        legend: { labels: { color: '#ccc' } },
+        legend: { labels: { color: getComputedStyle(document.documentElement).getPropertyValue('--text-secondary') || '#ccc' } },
         zoom: {
             zoom: {
                 wheel: { enabled: true },
@@ -403,7 +403,7 @@ const chartOptions = {
     font-size: 1.1rem;
 }
 .close-btn {
-    background: none; border: none; color: #fff; font-size: 1.5rem; cursor: pointer;
+    background: none; border: none; color: var(--text-primary); font-size: 1.5rem; cursor: pointer;
 }
 .explorer-body {
     flex: 1;
@@ -413,8 +413,8 @@ const chartOptions = {
 .explorer-sidebar {
     width: 300px;
     padding: 1.5rem;
-    background: rgba(0,0,0,0.2);
-    border-right: 1px solid rgba(255,255,255,0.1);
+    background: var(--surface-color);
+    border-right: 1px solid var(--surface-border);
     display: flex; flex-direction: column;
     gap: 2rem;
     overflow-y: auto;
@@ -438,15 +438,22 @@ const chartOptions = {
     flex: 1;
     padding: 0.25rem;
     font-size: 0.8rem;
-    background: rgba(255,255,255,0.1);
-    border: none; color: #fff; cursor: pointer;
+    background: var(--surface-color);
+    border: 1px solid var(--surface-border);
+    color: var(--text-primary);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
 }
-.presets button:hover { background: rgba(255,255,255,0.2); }
+.presets button:hover { background: var(--surface-hover); }
 .apply-btn {
     margin-top: 0.5rem;
     padding: 0.5rem;
-    background: #007bff; border: none; color: white; cursor: pointer;
+    background: var(--primary-color);
+    border: none;
+    color: var(--bg-color-start);
+    cursor: pointer;
     font-weight: bold;
+    border-radius: var(--radius-sm);
 }
 .sensor-list {
     display: flex;
@@ -464,10 +471,12 @@ const chartOptions = {
 .download-btn {
     margin-top: auto;
     padding: 0.75rem;
-    background: #28a745;
-    border: none; color: #fff;
+    background: var(--success-color);
+    border: none;
+    color: var(--bg-color-start);
     cursor: pointer;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
+    font-weight: 500;
 }
 .chart-toolbar {
     display: flex;
@@ -476,17 +485,21 @@ const chartOptions = {
 }
 .reset-btn {
     padding: 0.4rem 0.8rem;
-    background: #555;
-    border: 1px solid #777;
-    color: #fff;
+    background: var(--surface-color);
+    border: 1px solid var(--surface-border);
+    color: var(--text-primary);
     cursor: pointer;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-size: 0.85rem;
 }
 .reset-btn:hover {
-    background: #666;
+    background: var(--surface-hover);
 }
 input[type="datetime-local"] {
-    background: #333; border: 1px solid #555; color: #fff; padding: 0.25rem;
+    background: var(--surface-color);
+    border: 1px solid var(--surface-border);
+    color: var(--text-primary);
+    padding: 0.25rem;
+    border-radius: var(--radius-sm);
 }
 </style>

--- a/AscomAlpacaProxy/frontend-vue/src/stores/theme.js
+++ b/AscomAlpacaProxy/frontend-vue/src/stores/theme.js
@@ -1,0 +1,50 @@
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+
+export const useThemeStore = defineStore('theme', () => {
+    // Available themes
+    const THEMES = {
+        DEFAULT: 'default',
+        DARK: 'dark',
+        RED: 'red'
+    }
+
+    // Initialize from localStorage or default to DEFAULT
+    const currentTheme = ref(localStorage.getItem('theme') || THEMES.DEFAULT)
+
+    // Apply theme to document root
+    const applyTheme = (theme) => {
+        document.documentElement.setAttribute('data-theme', theme)
+    }
+
+    // Watch for theme changes and persist to localStorage
+    watch(currentTheme, (newTheme) => {
+        localStorage.setItem('theme', newTheme)
+        applyTheme(newTheme)
+    })
+
+    // Set theme
+    const setTheme = (theme) => {
+        if (Object.values(THEMES).includes(theme)) {
+            currentTheme.value = theme
+        }
+    }
+
+    // Toggle between themes
+    const toggleTheme = () => {
+        const themeOrder = [THEMES.DEFAULT, THEMES.DARK, THEMES.RED]
+        const currentIndex = themeOrder.indexOf(currentTheme.value)
+        const nextIndex = (currentIndex + 1) % themeOrder.length
+        currentTheme.value = themeOrder[nextIndex]
+    }
+
+    // Initialize theme on load
+    applyTheme(currentTheme.value)
+
+    return {
+        currentTheme,
+        THEMES,
+        setTheme,
+        toggleTheme
+    }
+})


### PR DESCRIPTION
I added two new themes for use in low light environments and at star parties with white light restrictions:

Dark theme:
<img width="1847" height="1719" alt="image" src="https://github.com/user-attachments/assets/af29b5f6-0c7a-4ddb-89e2-e7bb279195d7" />

Red theme:
<img width="1827" height="1712" alt="image" src="https://github.com/user-attachments/assets/c332457f-cd03-425a-acf1-5ebf8fa32c89" />

I also added an `isConnected` check to grey out the controls and display `--` when the device is not connected to prevent confusion. Prior to this when the device was not connected, it was still possible to toggle the switches in the UI and the Live Telemetry showed `0`s.

<img width="1824" height="905" alt="image" src="https://github.com/user-attachments/assets/af84b928-a542-4cc1-abc8-6d1ef11efbf2" />